### PR TITLE
Add ability to specify storage path prefix

### DIFF
--- a/cmd/backup-restore-tool/main.go
+++ b/cmd/backup-restore-tool/main.go
@@ -26,6 +26,7 @@ func init() {
 	rootCmd.PersistentFlags().String("storage-endpoint", "s3.amazonaws.com", "File storage endpoint.")
 	rootCmd.PersistentFlags().String("storage-bucket", "", "File storage bucket in which the backup should be stored.")
 	rootCmd.PersistentFlags().String("storage-region", "", "Storage region.")
+	rootCmd.PersistentFlags().String("storage-path-prefix", "", "Storage path prefix where under which the object will be stored.")
 	rootCmd.PersistentFlags().String("storage-object-key", "", "Object key under which backup file will be stored.")
 
 	rootCmd.PersistentFlags().String("storage-access-key", "", "File storage access key id.")

--- a/cmd/backup-restore-tool/options.go
+++ b/cmd/backup-restore-tool/options.go
@@ -11,10 +11,11 @@ func ConfigFromOptions() backuprestore.Config {
 			ConnectionString: viper.GetString("database"),
 		},
 		StorageConfig: backuprestore.StorageConfig{
-			Endpoint:  viper.GetString("storage-endpoint"),
-			Bucket:    viper.GetString("storage-bucket"),
-			Region:    viper.GetString("storage-region"),
-			ObjectKey: viper.GetString("storage-object-key"),
+			Endpoint:   viper.GetString("storage-endpoint"),
+			Bucket:     viper.GetString("storage-bucket"),
+			Region:     viper.GetString("storage-region"),
+			PathPrefix: viper.GetString("storage-path-prefix"),
+			ObjectKey:  viper.GetString("storage-object-key"),
 
 			AccessKey: viper.GetString("storage-access-key"),
 			SecretKey: viper.GetString("storage-secret-key"),

--- a/cmd/backup-restore-tool/options_test.go
+++ b/cmd/backup-restore-tool/options_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/backup-restore-tool/pkg/backuprestore"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFromOptions(t *testing.T) {
+	expectedConfig := backuprestore.Config{
+		DatabaseConfig: backuprestore.DatabaseConfig{
+			ConnectionString: "postgres://db",
+		},
+		StorageConfig: backuprestore.StorageConfig{
+			Endpoint:   "bifrost:80",
+			Bucket:     "my-bucket",
+			Region:     "east",
+			ObjectKey:  "backup-123",
+			PathPrefix: "my-backups",
+			AccessKey:  "abcd-key",
+			SecretKey:  "secret",
+			EnableTLS:  true,
+			Bifrost:    true,
+		},
+	}
+
+	viper.Set("database", "postgres://db")
+	viper.Set("storage-endpoint", "bifrost:80")
+	viper.Set("storage-bucket", "my-bucket")
+	viper.Set("storage-region", "east")
+	viper.Set("storage-path-prefix", "my-backups")
+	viper.Set("storage-object-key", "backup-123")
+	viper.Set("storage-access-key", "abcd-key")
+	viper.Set("storage-secret-key", "secret")
+	viper.Set("storage-tls", "true")
+	viper.Set("storage-type", "bifrost")
+
+	options := ConfigFromOptions()
+
+	require.Equal(t, expectedConfig, options)
+}

--- a/pkg/backuprestore/config.go
+++ b/pkg/backuprestore/config.go
@@ -15,10 +15,11 @@ type DatabaseConfig struct {
 }
 
 type StorageConfig struct {
-	Endpoint  string
-	Bucket    string
-	Region    string
-	ObjectKey string
+	Endpoint   string
+	Bucket     string
+	Region     string
+	ObjectKey  string
+	PathPrefix string
 
 	AccessKey string
 	SecretKey string


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add ability to specify storage path prefix for downloading and uploading backups from file store.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33707
