### PR TITLE
fix: cd env variable incorrectly using env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   IMAGE_NAME: mattermost/backup-restore-tool
-  LATEST_TAG: ${{ env.IMAGE_NAME }}:latest
+  LATEST_TAG: latest
 
 jobs:
   push:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

The continuous delivery workflow was incorrectly using the `env` inside the same `env` declaration.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

None
