### PR TITLE
fix: cd docker push not pushing correct tags

### DIFF
--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -26,7 +26,7 @@ runs:
       password: ${{ inputs.dockerhub-password }}
 
   # For pull requests use a custom tag: `pr-{pr number}`
-  - name: cd/push-docker-pr
+  - name: cd/push-docker-pr-tag
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
     if: ${{ github.event_name == 'pull_request' }}
     with:
@@ -34,14 +34,14 @@ runs:
       tags: ${{ inputs.image-name }}:pr-${{ github.event.number }}
 
   # If pushing to the main branch, push the 'latest' tag and the version tag
-  - name: cd/push-docker-tag
+  - name: cd/push-docker-version-tag
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
     if: ${{ inputs.is-release == 'yes' && github.event_name == 'push' && startsWith('v', github.ref_name) }}
     with:
       push: true
       tags: ${{ inputs.image-name }}:${{ github.ref_name }}
 
-  - name: cd/push-docker-latest
+  - name: cd/push-docker-latest-tag
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
     if: ${{ inputs.is-release == 'yes' && github.event_name == 'push' }}
     with:

--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -26,9 +26,9 @@ runs:
       password: ${{ inputs.dockerhub-password }}
 
   # For pull requests use a custom tag: `pr-{pr number}`
-  - name: cd/push-docker-ref
+  - name: cd/push-docker-pr
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
-    if: ${{ github.event_name == 'pull-request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     with:
       push: true
       tags: ${{ inputs.image-name }}:pr-${{ github.event.number }}

--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -13,9 +13,9 @@ inputs:
   image-name:
     description: 'The name of the image to build'
     required: true
-  main-branch:
-    description: 'The name of the main branch'
-    default: 'main'
+  is-release:
+    description: 'If the push is a release'
+    default: 'no'
 runs:
   using: "composite"
   steps:
@@ -25,26 +25,30 @@ runs:
       username: ${{ inputs.dockerhub-username }}
       password: ${{ inputs.dockerhub-password }}
 
-  - name: cd/generate-ref-tag
+  # For pull requests, use the short sha
+  - name: cd/generate-short-sha
     shell: bash
     run: |
-      if [ "${{ github.event_name }}" == "pull_request" ]
-      then
-        SHA=${{ github.event.pull_request.head.sha }}
-      else [ "${{ github.event_name }}"  == 'push' ]
-        SHA=${GITHUB_SHA}
-      fi
-      echo "REF_TAG=${SHA:0:7}" >> $GITHUB_ENV
+      echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   - name: cd/push-docker-ref
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
+    if: ${{ github.event_name == 'pull-request' }}
     with:
       push: true
-      tags: ${{ inputs.image-name }}:${{ env.REF_TAG }}
+      tags: ${{ inputs.image-name }}:${{ env.SHORT_SHA }}
+
+  # If pushing to the main branch, push the 'latest' tag and the version tag
+  - name: cd/push-docker-tag
+    uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
+    if: ${{ inputs.is-release == 'yes' && github.event_name == 'push' && startsWith('v', github.ref_name) }}
+    with:
+      push: true
+      tags: ${{ inputs.image-name }}:${{ github.ref_name }}
 
   - name: cd/push-docker-latest
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
-    if: ${{ github.ref_name == inputs.main-branch }}
+    if: ${{ inputs.is-release == 'yes' && github.event_name == 'push' }}
     with:
       push: true
       tags: ${{ inputs.image-name }}:${{ inputs.latest-tag }}

--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -27,9 +27,10 @@ runs:
 
   # For pull requests use a commit tag
   - name: Set outputs
-    id: vars
     shell: bash
-    run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+    run: |
+      SHA=${{ github.event.pull_request.head.sha }}
+      echo "SHORT_SHA=${SHA:0:7}" >> $GITHUB_ENV
 
   - name: cd/push-docker-pr-tag
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4

--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -25,18 +25,13 @@ runs:
       username: ${{ inputs.dockerhub-username }}
       password: ${{ inputs.dockerhub-password }}
 
-  # For pull requests, use the short sha
-  - name: cd/generate-short-sha
-    shell: bash
-    run: |
-      echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
+  # For pull requests use a custom tag: `pr-{pr number}`
   - name: cd/push-docker-ref
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
     if: ${{ github.event_name == 'pull-request' }}
     with:
       push: true
-      tags: ${{ inputs.image-name }}:${{ env.SHORT_SHA }}
+      tags: ${{ inputs.image-name }}:pr-${{ github.event.number }}
 
   # If pushing to the main branch, push the 'latest' tag and the version tag
   - name: cd/push-docker-tag

--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -25,7 +25,20 @@ runs:
       username: ${{ inputs.dockerhub-username }}
       password: ${{ inputs.dockerhub-password }}
 
-  # For pull requests use a custom tag: `pr-{pr number}`
+  # For pull requests use a commit tag
+  - name: Set outputs
+    id: vars
+    shell: bash
+    run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+  - name: cd/push-docker-pr-tag
+    uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
+    if: ${{ github.event_name == 'pull_request' }}
+    with:
+      push: true
+      tags: ${{ inputs.image-name }}:${{ env.SHORT_SHA }}
+
+  # For pull requests use a custom tag `pr-{pr number}` too
   - name: cd/push-docker-pr-tag
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,4 +28,4 @@ jobs:
         dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
         image-name: ${{ env.IMAGE_NAME }}
         latest-tag: ${{ env.LATEST_TAG }}
-        main-branch: main
+        is-release: 'yes'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

The previous continuous delivery workflow was not correctly generating the `latest` and `vX.X.X` tags. This will hopefully fix that. Also made a change to push tags on pull requests per pull request and not per commit, to save some space since I don't think we need that granularity.

The use of a string in the `is-release` input is due to a bug on the github workflows where booleans are not true boleans (and the linter complains about using a boolean in the default value, only allowing string or number).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

