### PR TITLE
fix: startsWith argument ordering

### DIFF
--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -50,7 +50,7 @@ runs:
   # If pushing to the main branch, push the 'latest' tag and the version tag
   - name: cd/push-docker-version-tag
     uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
-    if: ${{ inputs.is-release == 'yes' && github.event_name == 'push' && startsWith('v', github.ref_name) }}
+    if: ${{ inputs.is-release == 'yes' && github.event_name == 'push' && startsWith(github.ref_name, 'v') }}
     with:
       push: true
       tags: ${{ inputs.image-name }}:${{ github.ref_name }}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Fixes the ordering of the `startsWith` expression on the github workflows so that the push with tags works properly.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-50739
